### PR TITLE
Manually identify gdown.pl as Perl

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/gdown.pl linguist-language=Perl


### PR DESCRIPTION
For some reason, [linguist](https://github.com/github/linguist) is ignoring the shebang and sees the `:-` in one of the lines, causing it to detect as Prolog. Manually override the file type until it is fixed.